### PR TITLE
Implement changes suggested in my review of PR #988.

### DIFF
--- a/htdocs/js/apps/DatePicker/datepicker.js
+++ b/htdocs/js/apps/DatePicker/datepicker.js
@@ -1,119 +1,107 @@
-
 function WWDatePicker(name,reduced) {
-    
-    var open_rule = $('#' + name + '\\.open_date_id');
-    var due_rule = $('#' + name + '\\.due_date_id');
-    var answer_rule = $('#' + name + '\\.answer_date_id');
 
-    open_rule.change(function() {open_rule.addClass('changed')})
-	.blur(function() {update();});
-    due_rule.change(function() {due_rule.addClass('changed')})
-	.blur(function() {update();});
-    answer_rule.change(function() {answer_rule.addClass('changed')})
-	.blur(function() {update();});
-    
-    if (reduced) {
-	var reduced_rule = $('#' + name + '\\.reduced_scoring_date_id');
-	reduced_rule.change(function() {reduced_rule.addClass('changed')})
-	    .blur(function() {update();});
-    }
-        
-    open_rule.datetimepicker({
-        showOn: "button",
-	buttonText: "<i class='icon-calendar'></i>",
-	ampm: true,
-	timeFormat: 'hh:mmtt',
-	separator: ' at ',
-	constrainInput: false, 
-	onClose: function(dateText, inst) {
-	    open_rule.addClass('changed');
-            update();
-	},
-	
-    });
+	var open_rule = $('#' + name + '\\.open_date_id');
+	var due_rule = $('#' + name + '\\.due_date_id');
+	var answer_rule = $('#' + name + '\\.answer_date_id');
 
-    due_rule.datetimepicker({
-        showOn: "button",
-	buttonText: "<i class='icon-calendar'></i>",
-	ampm: true,
-	timeFormat: 'hh:mmtt',
-	separator: ' at ',
-	constrainInput: false, 
-	onClose: function(dateText, inst) {
-	    due_rule.addClass('changed');
-    	    update();
-	},
-    });
-    
-    answer_rule.datetimepicker({
-        showOn: "button",
-	buttonText: "<i class='icon-calendar'></i>",
-	ampm: true,
-	timeFormat: 'hh:mmtt',
-	separator: ' at ',
-	constrainInput: false, 
-	onClose: function(dateText, inst) {
-	    answer_rule.addClass('changed');
-    	    update();
-	},
-    });
-
-    if (reduced) {
-	reduced_rule.datetimepicker({
-            showOn: "button",
-	    buttonText: "<i class='icon-calendar'></i>",
-	    ampm: true,
-	    timeFormat: 'hh:mmtt',
-	    separator: ' at ',
-	    constrainInput: false, 
-	    onClose: function(dateText, inst) {
-		update();
-		reduced_rule.addClass('changed');
-	},
-	});
-    }
-
-    var getDate = function(element) {
-
-	if ($(element).val() == '') {
-	    return null;
-	} else {
-	    return element.datetimepicker('getDate');
+	var toggleChanged = function(e) {
+		var elt = $(this);
+		if (elt.val() != e.data.orig_value) elt.addClass('changed');
+		else elt.removeClass('changed');
 	}
-	
-    }
-    
-    var update = function() {
-	var openDate = getDate(open_rule);
-	var dueDate = getDate(due_rule);
-	var answerDate = getDate(answer_rule);
-	var reducedDate;
+
+	open_rule.change({ orig_value: open_rule.val() }, toggleChanged)
+		.blur(function() {update();});
+	due_rule.change({ orig_value: due_rule.val() }, toggleChanged)
+		.blur(function() {update();});
+	answer_rule.change({ orig_value: answer_rule.val() }, toggleChanged)
+		.blur(function() {update();});
 
 	if (reduced) {
-	    reducedDate = getDate(reduced_rule);
+		var reduced_rule = $('#' + name + '\\.reduced_scoring_date_id');
+		reduced_rule.change({ orig_value: reduced_rule.val() }, toggleChanged)
+			.blur(function() {update();});
 	}
-	
-	if (reduced && openDate && reducedDate && openDate > reducedDate ) {
-	    var reducedDate = new Date(openDate);
-	    reduced_rule.datetimepicker('setDate',reducedDate);
-	    reduced_rule.addClass('changed');
-	} else if (openDate && dueDate && openDate > dueDate) {
-	    dueDate = new Date(openDate);
-	    due_rule.datetimepicker('setDate',dueDate);
-	    due_rule.addClass('changed');
+
+	open_rule.datetimepicker({
+		showOn: "button",
+		buttonText: "<i class='icon-calendar'></i>",
+		ampm: true,
+		timeFormat: 'hh:mmtt',
+		separator: ' at ',
+		constrainInput: false,
+		onClose: update,
+	});
+
+	due_rule.datetimepicker({
+		showOn: "button",
+		buttonText: "<i class='icon-calendar'></i>",
+		ampm: true,
+		timeFormat: 'hh:mmtt',
+		separator: ' at ',
+		constrainInput: false,
+		onClose: update,
+	});
+
+	answer_rule.datetimepicker({
+		showOn: "button",
+		buttonText: "<i class='icon-calendar'></i>",
+		ampm: true,
+		timeFormat: 'hh:mmtt',
+		separator: ' at ',
+		constrainInput: false,
+		onClose: update,
+	});
+
+	if (reduced) {
+		reduced_rule.datetimepicker({
+			showOn: "button",
+			buttonText: "<i class='icon-calendar'></i>",
+			ampm: true,
+			timeFormat: 'hh:mmtt',
+			separator: ' at ',
+			constrainInput: false,
+			onClose: update,
+		});
 	}
-	
-	if (reduced && reducedDate && dueDate && reducedDate > dueDate)  {
-	    dueDate = new Date(reducedDate);
-	    due_rule.datetimepicker('setDate',dueDate);
-	    due_rule.addClass('changed');
+
+	var getDate = function(element) {
+
+		if (element.val() == '') {
+			return null;
+		} else {
+			return element.datetimepicker('getDate');
+		}
+
 	}
-	
-	if (dueDate && answerDate && dueDate > answerDate) {
-	    answerDate = new Date(dueDate);
-	    answer_rule.datetimepicker('setDate',answerDate);
-	    answer_rule.addClass('changed');
+
+	var update = function() {
+		var openDate = getDate(open_rule);
+		var dueDate = getDate(due_rule);
+		var answerDate = getDate(answer_rule);
+		var reducedDate;
+
+		if (reduced) {
+			reducedDate = getDate(reduced_rule);
+		}
+
+		if (reduced && openDate && reducedDate && openDate > reducedDate ) {
+			var reducedDate = new Date(openDate);
+			reduced_rule.datetimepicker('setDate',reducedDate);
+		} else if (openDate && dueDate && openDate > dueDate) {
+			dueDate = new Date(openDate);
+			due_rule.datetimepicker('setDate',dueDate);
+		}
+
+		if (reduced && reducedDate && dueDate && reducedDate > dueDate)  {
+			dueDate = new Date(reducedDate);
+			due_rule.datetimepicker('setDate',dueDate);
+		}
+
+		if (dueDate && answerDate && dueDate > answerDate) {
+			answerDate = new Date(dueDate);
+			answer_rule.datetimepicker('setDate',answerDate);
+		}
+
 	}
-	
-    }
 }

--- a/htdocs/js/apps/DatePicker/datepicker.js
+++ b/htdocs/js/apps/DatePicker/datepicker.js
@@ -75,7 +75,7 @@ function WWDatePicker(name,reduced) {
 
     var getDate = function(element) {
 
-	if ($(element).val() == 'None Specified') {
+	if ($(element).val() == '') {
 	    return null;
 	} else {
 	    return element.datetimepicker('getDate');

--- a/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm
@@ -115,30 +115,18 @@ use constant FIELD_PROPERTIES => {
 		type      => "edit",
 		size      => "25",
 		override  => "any",
-		labels    => {
-				#0 => "None Specified",
-				"" => x("None Specified"),
-		},
 	},
 	due_date => {
 		name      => x("Closes"),
 		type      => "edit",
 		size      => "25",
 		override  => "any",
-		labels    => {
-				#0 => "None Specified",
-				"" => x("None Specified"),
-		},
 	},
 	answer_date => {
 		name      => x("Answers Available"),
 		type      => "edit",
 		size      => "25",
 		override  => "any",
-		labels    => {
-				#0 => "None Specified",
-				"" => x("None Specified"),
-		},
 	},
 	visible => {
 		name      => x("Visible to Students"),
@@ -165,20 +153,12 @@ use constant FIELD_PROPERTIES => {
 		type      => "edit",
 		size      => "25",
 		override  => "any",
-		labels    => {
-				#0 => "None Specified",
-				"" => x("None Specified"),
-		},
 	},
 	restricted_release => {
 		name      => x("Restrict release by set(s)"),
 		type      => "edit",
 		size      => "30",
 		override  => "any",
-		labels    => {
-				#0 => "None Specified",
-				"" => x("None Specified"),
-		},
                 help_text => x("This set will be unavailable to students until they have earned a certain score on the sets specified in this field.  The sets should be written as a comma separated list.  The minimum score required on the sets is specified in the following field.")
 	},
 	restricted_status => {
@@ -710,23 +690,23 @@ sub FieldHTML {
 	# if we are creating override feilds we should add the js to automatically check the
 	# override box.
 	if ($forUsers && $check) {
-	    $onChange = "\$('#$recordType\\\\.$recordID\\\\.$field\\\\.override_id').attr('checked',true)";
-			$onKeyUp = "\$('#$recordType\\\\.$recordID\\\\.$field\\\\.override_id').attr('checked',true)";
-			$uncheckBox = "\$('#$recordType\\\\.$recordID\\\\.$field\\\\.override_id').attr('checked',false)";
-			$resetClass = "\$('#$recordType\\\\.$recordID\\\\.${field}_id').attr('class', 'hasDatepicker')";
+		$onChange = "\$('input[id=\"$recordType.$recordID.$field.override_id\"]').prop('checked',true)";
+		$onKeyUp = "\$('input[id=\"$recordType.$recordID.$field.override_id\"]').prop('checked',true)";
+		$uncheckBox = "\$('input[id=\"$recordType.$recordID.$field.override_id\"]').prop('checked',false)";
+		$resetClass = "\$('input[id=\"$recordType.$recordID.${field}_id').attr('class', 'hasDatepicker')";
 	}
 
 	if ($edit) {
 		$inputType = CGI::font({class=>"visible"}, CGI::input({
-		                type => "text",
+				type => "text",
 				name => "$recordType.$recordID.$field",
 				id   => "$recordType.$recordID.${field}_id",
 				value => $r->param("$recordType.$recordID.$field") || ($forUsers ? $userValue : $globalValue),
 				size => $properties{size} || 5,
+				placeholder => $field =~ /_date/ ? x("None Specified") : '',
 				onChange => $onChange,
 				onkeyup => $onKeyUp,
-				onfocus => "if (this.value=='None Specified') { this.value = ''; }",
-				onblur => "if (this.value == '') { this.value = 'None Specified'; $uncheckBox; $resetClass; }",
+				onblur => "if (this.value == '') { $uncheckBox; $resetClass; }",
 		}));
 
 	} elsif ($choose) {

--- a/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm
@@ -685,15 +685,14 @@ sub FieldHTML {
 	my $onChange = "";
 	my $onKeyUp = "";
 	my $uncheckBox = "";
-	my $resetClass = "";
 
 	# if we are creating override feilds we should add the js to automatically check the
 	# override box.
 	if ($forUsers && $check) {
 		$onChange = "\$('input[id=\"$recordType.$recordID.$field.override_id\"]').prop('checked',true)";
 		$onKeyUp = "\$('input[id=\"$recordType.$recordID.$field.override_id\"]').prop('checked',true)";
-		$uncheckBox = "\$('input[id=\"$recordType.$recordID.$field.override_id\"]').prop('checked',false)";
-		$resetClass = "\$('input[id=\"$recordType.$recordID.${field}_id').attr('class', 'hasDatepicker')";
+		$uncheckBox = "if (this.value == '')"
+			. "\$('input[id=\"$recordType.$recordID.$field.override_id\"]').prop('checked',false);";
 	}
 
 	if ($edit) {
@@ -706,7 +705,7 @@ sub FieldHTML {
 				placeholder => $field =~ /_date/ ? x("None Specified") : '',
 				onChange => $onChange,
 				onkeyup => $onKeyUp,
-				onblur => "if (this.value == '') { $uncheckBox; $resetClass; }",
+				onblur => $uncheckBox,
 		}));
 
 	} elsif ($choose) {

--- a/lib/WeBWorK/ContentGenerator/Instructor/UserDetail.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/UserDetail.pm
@@ -390,7 +390,7 @@ sub checkDates {
 	foreach my $field (@{DATE_FIELDS_ORDER()}) {  # check that override dates can be parsed and are not blank
 		$dates{$field} = $setRecord->$field;
 		if (defined  $r->param("set.$setID.$field.override") &&
-		    $r->param("set.$setID.$field") ne 'None Specified'){
+		    $r->param("set.$setID.$field") ne ''){
 			eval{ $numerical_date = $self->parseDateTime($r->param("set.$setID.$field"))};
 			unless( $@  ) {
 					$dates{$field}=$numerical_date;
@@ -481,8 +481,8 @@ sub DBFieldTable {
 		my $userValue = defined $UserRecord ? $UserRecord->$field : $globalValue;
 		my $mergedValue  = defined $MergedRecord ? $MergedRecord->$field : $globalValue;
 
-		my $onChange = "\$('#$recordType\\\\.$recordID\\\\.$field\\\\.override_id').attr('checked',true)";
-		my $onKeyUp = "\$('#$recordType\\\\.$recordID\\\\.$field\\\\.override_id').attr('checked',true)";
+		my $onChange = "\$('input[id=\"$recordType.$recordID.$field.override_id\"]').prop('checked',true)";
+		my $onKeyUp = "\$('input[id=\"$recordType.$recordID.$field.override_id\"]').prop('checked',true)";
 
 		push @results,
 			[$r->maketext($rh_fieldLabels->{$field}).' ',
@@ -497,14 +497,14 @@ sub DBFieldTable {
 				}) : "",
 				defined $UserRecord ?
 					(CGI::input({ -name=>"$recordType.$recordID.$field",
-						      -id =>"$recordType.$recordID.${field}_id",
-						      -type=> "text",
-					        -value => $userValue ? $self->formatDateTime($userValue,'','%m/%d/%Y at %I:%M%P') : "None Specified",
-						      -onchange => $onChange,
-						      -onkeyup => $onKeyUp,
-						      -onfocus => "if (this.value=='None Specified') { this.value = ''; }",
-						      -onblur => "if (this.value == '') { this.value = 'None Specified'; \$('#$recordType\\\\.$recordID\\\\.$field\\\\.override_id').attr('checked',false); \$('#$recordType\\\\.$recordID\\\\.${field}_id').attr('class', 'hasDatepicker'); }",
-					        -size => 25})
+							-id =>"$recordType.$recordID.${field}_id",
+							-type=> "text",
+							-value => $userValue ? $self->formatDateTime($userValue,'','%m/%d/%Y at %I:%M%P') : "",
+							-onchange => $onChange,
+							-onkeyup => $onKeyUp,
+							-placeholder => x("None Specified"),
+							-onblur => "\$('input[id=\"$recordType.$recordID.$field.override_id\"]').prop('checked',false); \$('input[id=\"$recordType.$recordID.${field}_id\"]').attr('class', 'hasDatepicker'); }",
+							-size => 25})
 					) : "",
 				$self->formatDateTime($globalValue,'','%m/%d/%Y at %I:%M%P'),
 			]

--- a/lib/WeBWorK/ContentGenerator/Instructor/UserDetail.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/UserDetail.pm
@@ -481,9 +481,6 @@ sub DBFieldTable {
 		my $userValue = defined $UserRecord ? $UserRecord->$field : $globalValue;
 		my $mergedValue  = defined $MergedRecord ? $MergedRecord->$field : $globalValue;
 
-		my $onChange = "\$('input[id=\"$recordType.$recordID.$field.override_id\"]').prop('checked',true)";
-		my $onKeyUp = "\$('input[id=\"$recordType.$recordID.$field.override_id\"]').prop('checked',true)";
-
 		push @results,
 			[$r->maketext($rh_fieldLabels->{$field}).' ',
 			 defined $UserRecord ?
@@ -500,10 +497,11 @@ sub DBFieldTable {
 							-id =>"$recordType.$recordID.${field}_id",
 							-type=> "text",
 							-value => $userValue ? $self->formatDateTime($userValue,'','%m/%d/%Y at %I:%M%P') : "",
-							-onchange => $onChange,
-							-onkeyup => $onKeyUp,
+							-onchange => "\$('input[id=\"$recordType.$recordID.$field.override_id\"]').prop('checked',true)",
+							-onkeyup => "\$('input[id=\"$recordType.$recordID.$field.override_id\"]').prop('checked',true)",
 							-placeholder => x("None Specified"),
-							-onblur => "\$('input[id=\"$recordType.$recordID.$field.override_id\"]').prop('checked',false); \$('input[id=\"$recordType.$recordID.${field}_id\"]').attr('class', 'hasDatepicker'); }",
+							-onblur => "if (this.value == '')"
+								. "\$('input[id=\"$recordType.$recordID.$field.override_id\"]').prop('checked',false);",
 							-size => 25})
 					) : "",
 				$self->formatDateTime($globalValue,'','%m/%d/%Y at %I:%M%P'),


### PR DESCRIPTION
Improve the jQuery selectors so that escaping of dots are not needed.
This has the benefit of not needing to deal with escaping special
characters that may appear in the variable $recordID.

Switch from using attr to prop as that is the proper thing to use in
this situation.

Change from the "None Specified" text input value to using a
placeholder.