### PR TITLE
Fix check_latex.tex compilation via pdflatex with `\input`, and add a script to compile it

### DIFF
--- a/bin/check_latex
+++ b/bin/check_latex
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" > /dev/null 2>&1 && pwd)"
+
+TEMP_DIR=$(mktemp -d -t check_latex_XXXXXXXX)
+
+TEXINPUTS=$SCRIPT_DIR:$SCRIPT_DIR/../conf/snippets/hardcopyThemes/common: \
+	pdflatex -interaction nonstopmode check_latex.tex > $TEMP_DIR/check_latex.nfo 2>&1
+
+if [ $? == 0 ]
+then
+	echo "Compilation Success!"
+else
+	cat $TEMP_DIR/check_latex.nfo
+	echo
+	echo "Compilation Failure: Examine the latex output above to see what went wrong."
+	echo "You may also examine $PWD/check_latex.log and $PWD/check_latex.aux."
+fi
+
+rm -r $TEMP_DIR

--- a/bin/check_latex.tex
+++ b/bin/check_latex.tex
@@ -15,18 +15,12 @@
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 \documentclass[10pt]{amsart}
-\usepackage{amsmath,amsfonts,amssymb,multicol}
-\usepackage{booktabs,tabularx,colortbl,caption,xcolor}
-\usepackage{path}
-  \discretionaries |~!@$%^&*()_+`-=#{"}[]:;'<>,.?\/abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789|
-\usepackage[pdftex]{graphicx}
-\usepackage[active,textmath,displaymath]{preview}  % needed for dvipng
-\usepackage{epstopdf} % needed for eps graphics in CAPA
-\usepackage{epsf}   
-\usepackage{epsfig}   % needed for eps graphics in CAPA
-\usepackage{pslatex}
-\usepackage{fullpage} % needed for ``single column'' hardcopy format
+
 \input{packages.tex}
+
+\usepackage[active,textmath,displaymath]{preview}  % needed for dvipng
+\usepackage{geometry} % needed for ``two column'' hardcopy format
+\usepackage{fullpage} % needed for ``single column'' hardcopy format
 
 \pagestyle{plain}
 \textheight 9in
@@ -35,29 +29,8 @@
 \textwidth= 7.28in
 \columnsep = .25in
 \columnseprule = .4pt
-\def\endline{\bigskip\hrule width \hsize height 0.8pt }
-\newcommand{\lt}{<}
-\newcommand{\gt}{>}
-\newcommand{\less}{<}
-\newcommand{\grt}{>}
 
-% BEGIN capa tex macros
-
-\newcommand{\capa}{{\sl C\kern-.10em\raise-.00ex\hbox{\rm A}\kern-.22em%
-{\sl P}\kern-.14em\kern-.01em{\rm A}}}
-  
-\newenvironment{choicelist}
-{\begin{list}{}
-	{\setlength{\rightmargin}{0in}\setlength{\leftmargin}{0.13in}
-	\setlength{\topsep}{0.05in}\setlength{\itemsep}{0.022in}
-	\setlength{\parsep}{0in}\setlength{\belowdisplayskip}{0.04in}
-	\setlength{\abovedisplayskip}{0.05in}
-	\setlength{\abovedisplayshortskip}{-0.04in}
-	\setlength{\belowdisplayshortskip}{0.04in}}
-	}
-{\end{list}}
-
-% END capa tex macros 
+\input{CAPA.tex}
 
 \begin{document}
 \voffset=-0.8in
@@ -66,12 +39,10 @@
 \begin{multicols}{2}
 \columnwidth=\linewidth
 
-
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 Testing the LaTeX set up for WeBWorK.
 %{\includegraphics[width = 3.5 in]{prob03av8.pdf}}
-
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 


### PR DESCRIPTION
Adding `\input{packages.tex}` without removing the `\newcommand` calls from check_latex.tex causes pdflatex to fail.  This removes those and the other redundancies.  This also adds `\input{CAPA.tex}`.  The result is basically what is used in Hardcopy.pm.

Using `\input` complicates running pdfltex successfully.  So a script is added to make that easier.  There are different ways that this can be done.  Here I chose to just set TEXINPUTS to check the directory containing the check_latex script and the location where `package.tex` and `CAPA.tex` are stored.  Alternately, a relative path from /opt/webwork/webork2/bin to that location could be added to the check_latex.tex file, and then pdflatex would need to be either run from the bin directory, or TEXINPUTS set to be only that directory.

You can do what you will with this.  Perhaps even better would be to create a perl script to run pdflatex.  Then you could even obtain the `$externalPrograms{pdflatex}` value from the conf files, and do other nice things.  This is a quick and easy solution.