### PR TITLE
Fixes and improvements for achievement notifications.

### DIFF
--- a/conf/defaults.config
+++ b/conf/defaults.config
@@ -373,9 +373,10 @@ $courseDirs{templates}   = "$courseDirs{root}/templates";
 $courseDirs{hardcopyThemes} = "$courseDirs{templates}/hardcopyThemes";
 
 # Location of course achievement files.
-$courseDirs{achievements}   = "$courseDirs{templates}/achievements";
-$courseDirs{achievements_html} = "$courseDirs{html}/achievements"; #contains badge icons
-$courseURLs{achievements}   = "$courseURLs{html}/achievements";
+$courseDirs{achievements}              = "$courseDirs{templates}/achievements";
+$courseDirs{achievement_notifications} = "$courseDirs{achievements}/notifications";
+$courseDirs{achievements_html}         = "$courseDirs{html}/achievements";                     #contains badge icons
+$courseURLs{achievements}              = "$courseURLs{html}/achievements";
 
 # Location of course-specific macro files.
 $courseDirs{macros}      = "$courseDirs{templates}/macros";
@@ -1632,7 +1633,8 @@ $ConfigValues = [
 			var  => 'mail{achievementEmailFrom}',
 			doc  => x('Email address to use when sending Achievement notifications.'),
 			doc2 => x(
-				'This email address will be used as the sender (both From: and Reply-To:) for achievement notifications.'
+				'This email address will be used as the sender for achievement notifications. '
+				. 'Achievement notifications will not be sent unless this is set.'
 			),
 			width => 45,
 			type  => 'text'

--- a/courses.dist/modelCourse/templates/achievements/notifications/default.html.ep
+++ b/courses.dist/modelCourse/templates/achievements/notifications/default.html.ep
@@ -1,10 +1,12 @@
-$FN
+<%= $user->first_name %>
 
 Congratulations, you just earned the "<%= $achievement->{name} %>" achievement!
 
 <%= $achievement->{description} %>
 
+% if ($nextLevelPoints) {
 You have <%= $nextLevelPoints - $pointsEarned %> points remaining until your next level-up.
 
+% }
 Great job!
 --Prof. X

--- a/courses.dist/modelCourse/templates/achievements/notifications/default.html.ep
+++ b/courses.dist/modelCourse/templates/achievements/notifications/default.html.ep
@@ -1,4 +1,4 @@
-<%= $user->first_name %>
+<%= $user->first_name %>,
 
 Congratulations, you just earned the "<%= $achievement->{name} %>" achievement!
 

--- a/lib/Mojolicious/WeBWorK/Tasks/AchievementNotification.pm
+++ b/lib/Mojolicious/WeBWorK/Tasks/AchievementNotification.pm
@@ -23,7 +23,7 @@ use WeBWorK::Debug qw(debug);
 use WeBWorK::CourseEnvironment;
 use WeBWorK::DB;
 use WeBWorK::Localize;
-use WeBWorK::Utils qw/processEmailMessage createEmailSenderTransportSMTP/;
+use WeBWorK::Utils qw(createEmailSenderTransportSMTP);
 
 # send student notification that they have earned an achievement
 sub run ($job, $mail_data) {
@@ -47,54 +47,41 @@ sub run ($job, $mail_data) {
 	my $result_message = eval { $job->send_achievement_notification($ce, $db, $mail_data) };
 	if ($@) {
 		$job->app->log->error($job->maketext("An error occurred while trying to send email: $@"));
-		return $job->fail($job->maketext("An error occurred while trying to send email: [_1]", $@));    # fail silently
+		return $job->fail($job->maketext("An error occurred while trying to send email: [_1]", $@));
 	}
 	$job->app->log->info("Message sent to $mail_data->{recipient}");
-	return $job->finish($job->maketext("Message sent to [_1]", $mail_data->{recipient}));    # succeed silently
+	return $job->finish($job->maketext("Message sent to [_1]", $mail_data->{recipient}));
 }
 
 sub send_achievement_notification ($job, $ce, $db, $mail_data) {
-	if ($ce->{mail}{achievementEmailSender} || $ce->{mail}{smtpSender} || $ce->{mail}{set_return_path}) {
-		$mail_data->{from} =
-			$ce->{mail}{achievementEmailSender} || $ce->{mail}{smtpSender} || $ce->{mail}{set_return_path};
-	} else {
-		die "Cannot send system email without one of: mail{set_return_path} or mail{smtpSender}";
-	}
+	my $from = $ce->{mail}{achievementEmailFrom};
+	die 'Cannot send achievement email notification without mail{achievementEmailFrom}.' unless $from;
 
-	my $recipient = $mail_data->{recipient};
-	my $template  = $ce->{courseDirs}{achievements} . '/' . $mail_data->{achievement}{email_template};
-	my $renderer  = Mojo::Template->new(vars => 1);
+	my $user_record = $db->getUser($mail_data->{recipient});
+	die "Record for user $mail_data->{recipient} not found\n" unless ($user_record);
+	die "User $mail_data->{recipient} does not have an email address -- skipping\n"
+		unless ($user_record->email_address =~ /\S/);
+
+	my $template = "$ce->{courseDirs}{achievement_notifications}/$mail_data->{achievement}{email_template}";
+	my $renderer = Mojo::Template->new(vars => 1);
 
 	# what other data might need to be passed to the template?
-	$mail_data->{body} = $renderer->render_file(
+	my $body = $renderer->render_file(
 		$template,
 		{
-			ce              => $ce,                             # holds achievement URLs
-			achievement     => $mail_data->{achievement},       # full db record
+			ce              => $ce,                                               # holds achievement URLs
+			achievement     => $mail_data->{achievement},                         # full db record
 			setID           => $mail_data->{set_id},
 			nextLevelPoints => $mail_data->{nextLevelPoints},
 			pointsEarned    => $mail_data->{pointsEarned},
+			user            => $user_record,
+			user_status     => $ce->status_abbrev_to_name($user_record->status)
 		}
 	);
 
-	my $user_record = $db->getUser($recipient);
-	unless ($user_record) {
-		die "Record for user $recipient not found\n";
-	}
-	unless ($user_record->email_address =~ /\S/) {
-		die "User $recipient does not have an email address -- skipping\n";
-	}
-
-	# parse email template similar to how it is done in SendMail.pm
-	my $msg = processEmailMessage(
-		$mail_data->{body}, $user_record,
-		$ce->status_abbrev_to_name($user_record->status),
-		$mail_data->{merge_data}
-	);
-
 	my $email =
-		Email::Stuffer->to($user_record->email_address)->from($mail_data->{from})->subject($mail_data->{subject})
-		->text_body($msg)->header('X-Remote-Host' => $mail_data->{remote_host});
+		Email::Stuffer->to($user_record->email_address)->from($from)->subject($mail_data->{subject})->text_body($body)
+		->header('X-Remote-Host' => $mail_data->{remote_host});
 
 	$email->send_or_die({
 		transport => createEmailSenderTransportSMTP($ce),
@@ -102,7 +89,7 @@ sub send_achievement_notification ($job, $ce, $db, $mail_data) {
 	});
 	debug 'email sent successfully to ' . $user_record->email_address;
 
-	return $job->maketext('Message sent to [_1] at [_2].', $recipient, $user_record->email_address) . "\n";
+	return $job->maketext('Message sent to [_1] at [_2].', $mail_data->{recipient}, $user_record->email_address) . "\n";
 }
 
 sub maketext ($job, @args) {

--- a/lib/WeBWorK/AchievementEvaluator.pm
+++ b/lib/WeBWorK/AchievementEvaluator.pm
@@ -264,7 +264,7 @@ sub checkForAchievements ($problem_in, $pg, $c, %options) {
 					pointsEarned    => $achievementPoints,
 					remote_host     => $c->tx->remote_address || "UNKNOWN",
 				} ]
-			) if ($achievement->email_template);
+			) if ($ce->{mail}{achievementEmailFrom} && $achievement->email_template);
 		}
 
 		#update counter, nfreeze_base64 localData and store

--- a/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm
@@ -103,10 +103,6 @@ sub initialize ($c) {
 	return;
 }
 
-sub page_title ($c) {
-	return $c->maketext('Achievement Evaluator for achievement [_1]', $c->stash('achievementID'));
-}
-
 # Convert long paths to [ACHEVDIR]
 sub shortPath ($c, $file) {
 	my $ache = $c->ce->{courseDirs}{achievements};

--- a/lib/WeBWorK/SafeTemplate.pm
+++ b/lib/WeBWorK/SafeTemplate.pm
@@ -1,0 +1,29 @@
+package WeBWorK::SafeTemplate;
+use Mojo::Base 'Mojo::Template';
+
+# The Mojo::Template _wrap method adds "use Mojo::Base -strict" and "no warnings 'ambiguous'" to the code generated in
+# this method.  When that is called later it causes an error in the safe compartment because "require" is trapped. So
+# instead this imports strict, warnings, and utf8 which is equivalent to calling "use Mojo::Base -strict". Calling "no
+# warnings 'ambiguous'" prevents warnings from a lack of parentheses on a scalar call in the generated code.  So if this
+# package is used, those warnings need to be prevented in another way.
+sub _wrap {
+	my ($self, $body, $vars) = @_;
+
+	# Variables
+	my $args = '';
+	if ($self->vars && (my @vars = grep {/^\w+$/} keys %$vars)) {
+		$args = 'my (' . join(',', map {"\$$_"} @vars) . ')';
+		$args .= '= @{shift()}{qw(' . join(' ', @vars) . ')};';
+	}
+
+	# Wrap lines
+	my $num  = () = $body =~ /\n/g;
+	my $code = $self->_line(1) . "\npackage @{[$self->namespace]};";
+	$code .= 'BEGIN { strict->import; warnings->import; utf8->import; }';
+	$code .= "sub { my \$_O = ''; @{[$self->prepend]};{ $args { $body\n";
+	$code .= $self->_line($num + 1) . "\n;}@{[$self->append]}; } \$_O };";
+
+	return $code;
+}
+
+1;

--- a/lib/WeBWorK/Utils/CourseIntegrityCheck.pm
+++ b/lib/WeBWorK/Utils/CourseIntegrityCheck.pm
@@ -360,11 +360,12 @@ sub updateCourseDirectories {
 
 	# These are the directories in the model course that can be copied if not found in this course.
 	my %model_course_dirs = (
-		templates         => 'templates',
-		html              => 'html',
-		achievements      => 'templates/achievements',
-		email             => 'templates/email',
-		achievements_html => 'html/achievements'
+		templates                 => 'templates',
+		html                      => 'html',
+		achievements              => 'templates/achievements',
+		achievement_notifications => 'templates/achievements/notifications',
+		email                     => 'templates/email',
+		achievements_html         => 'html/achievements'
 	);
 
 	my $permissions = path($ce->{courseDirs}{root})->stat->mode & 0777;

--- a/lib/WeBWorK/Utils/Routes.pm
+++ b/lib/WeBWorK/Utils/Routes.pm
@@ -468,12 +468,12 @@ my %routeParameters = (
 		path   => '/achievement_list'
 	},
 	instructor_achievement_editor => {
-		title  => '[_5]',
+		title  => 'Achievement Evaluator for achievement [_5]',
 		module => 'Instructor::AchievementEditor',
 		path   => '/#achievementID/editor'
 	},
 	instructor_achievement_user_editor => {
-		title  => x('Achievement User Editor'),
+		title  => x('Achievement Users for [_5]'),
 		module => 'Instructor::AchievementUserEditor',
 		path   => '/#achievementID/users'
 	},

--- a/templates/ContentGenerator/Base/links.html.ep
+++ b/templates/ContentGenerator/Base/links.html.ep
@@ -316,7 +316,7 @@
 			% if ($ce->{LTIGradeMode} && $authz->hasPermissions($userID, 'score_sets')) {
 				<li class="list-group-item nav-item"><%= $makelink->('instructor_lti_update') %></li>
 			% }
-			% # Achievment Editor
+			% # Achievement Editor
 			% if ($ce->{achievementsEnabled} && $authz->hasPermissions($userID, 'edit_achievements')) {
 				<li class="list-group-item nav-item"><%= $makelink->('instructor_achievement_list') %></li>
 				% if (defined $achievementID) {
@@ -325,7 +325,21 @@
 							<li class="nav-item">
 								<%= $makelink->(
 									'instructor_achievement_editor',
-									text     => $achievementID =~ s/_/ /gr,
+									text     => maketext('[_1] evaluator', $achievementID =~ s/_/ /gr),
+									captures => { achievementID => $achievementID },
+								) %>
+							</li>
+							<li class="nav-item">
+								<%= $makelink->(
+									'instructor_achievement_notification',
+									text     => maketext('[_1] notifications', $achievementID =~ s/_/ /gr),
+									captures => { achievementID => $achievementID },
+								) %>
+							</li>
+							<li class="nav-item">
+								<%= $makelink->(
+									'instructor_achievement_user_editor',
+									text     => maketext('[_1] users', $achievementID =~ s/_/ /gr),
 									captures => { achievementID => $achievementID },
 								) %>
 							</li>

--- a/templates/ContentGenerator/Instructor/AchievementList/default_table.html.ep
+++ b/templates/ContentGenerator/Instructor/AchievementList/default_table.html.ep
@@ -68,7 +68,7 @@
 								? maketext('Edit Email Template')
 								: maketext('Enable Email Notification') =%>
 						<% end =%>
-          </td>
+					</td>
 					<td class="text-nowrap">
 						<%= link_to maketext('Edit Evaluator') => $c->systemLink(
 							url_for('instructor_achievement_editor', achievementID => $achievement_id),

--- a/templates/ContentGenerator/Instructor/AchievementNotificationEditor/existing_form.html.ep
+++ b/templates/ContentGenerator/Instructor/AchievementNotificationEditor/existing_form.html.ep
@@ -1,8 +1,16 @@
+% use Mojo::File qw(path);
+%
 <div class="row align-items-center mb-2">
 	<%= label_for 'action.existing.target_file_id' => maketext('Use existing template:'),
 		class => 'col-form-label col-auto' =%>
 	<div class="col-auto">
-		<%= text_field 'action.existing.target_file' => $c->getRelativeSourceFilePath($c->{sourceFilePath}),
-			id => 'action.existing.target_file_id', size => 40, class => 'form-control form-control-sm' =%>
+		% my $relativeSourceFilePath = $c->getRelativeSourceFilePath($c->{sourceFilePath});
+		<%= select_field 'action.existing.target_file' => [
+				map { [ $_ =~ s/(\.html)?\.ep//r => $_, $_ eq $relativeSourceFilePath ? (selected => undef) : () ] }
+				@{ path($ce->{courseDirs}{achievement_notifications})->list->grep(qr/\.ep$/)
+					->map(sub { $c->getRelativeSourceFilePath($_) })->to_array }
+			],
+			id => 'action.existing.target_file_id', class => 'form-select form-select-sm d-inline w-auto',
+			dir => 'ltr' =%>
 	</div>
 </div>

--- a/templates/ContentGenerator/Instructor/AchievementNotificationEditor/save_as_form.html.ep
+++ b/templates/ContentGenerator/Instructor/AchievementNotificationEditor/save_as_form.html.ep
@@ -1,34 +1,13 @@
 <div>
 	<div class="row align-items-center mb-2">
 		<%= label_for 'action.save_as.target_file_id' => maketext('Save as:'), class => 'col-form-label col-auto' =%>
-		<div class="col-auto">
-			<%= text_field 'action.save_as.target_file' => $c->getRelativeSourceFilePath($c->{sourceFilePath}),
-				id => 'action.save_as.target_file_id', size => 40, class => 'form-control form-control-sm' =%>
+		<div class="col-auto d-inline-flex" dir="ltr">
+			<div class="editor-save-path input-group input-group-sm">
+				<span class="input-group-text">[ACHEVNOTIFYDIR]/</span>
+				% param('action.save_as.target_file', $c->getRelativeSourceFilePath($c->{sourceFilePath}));
+				<%= text_field 'action.save_as.target_file' => '', id => 'action.save_as.target_file_id', size => 40,
+					class => 'form-control form-control-sm', dir  => 'ltr' =%>
+			</div>
 		</div>
-		<%=  hidden_field 'action.save_as.source_file' => $c->{sourceFilePath} =%>
-	</div>
-	<div class="form-check mb-2">
-		<%= radio_button 'action.save_as.saveMode' => 'use_in_current',
-			id => 'action.save_as.saveMode.use_in_current', class => 'form-check-input' =%>
-		<%= label_for 'action.save_as.saveMode.use_in_current', class => 'form-check-label', begin =%>
-			<%== maketext('Use in achievement [_1]', tag('b', $achievementID)) =%>
-		<% end =%>
-	</div>
-	<div class="mb-2">
-		<div class="form-check d-inline-block">
-			<%= radio_button 'action.save_as.saveMode' => 'use_in_new',
-				id => 'action.save_as.saveMode.use_in_new', class => 'form-check-input' =%>
-			<%= label_for 'action.save_as.saveMode.use_in_new' => maketext('Use in new achievement:'),
-				class => 'form-check-label me-1', id => 'action.save_as.saveMode.use_in_new.label' =%>
-		</div>
-		<%= text_field 'action.save_as.id' => '',
-			'aria-labelledby' => 'action.save_as.saveMode.use_in_new.label',
-			class             => 'form-control form-control-sm d-inline w-auto' =%>
-	</div>
-	<div class="form-check">
-		<%= radio_button 'action.save_as.saveMode' => 'dont_use',
-			id => 'action.save_as.saveMode.dont_use', class => 'form-check-input' =%>
-		<%= label_for 'action.save_as.saveMode.dont_use' => maketext(q{Don't use in an achievement}),
-			class => 'form-check-label' =%>
 	</div>
 </div>

--- a/templates/HelpFiles/InstructorAchievementNotificationEditor.html.ep
+++ b/templates/HelpFiles/InstructorAchievementNotificationEditor.html.ep
@@ -1,0 +1,58 @@
+%################################################################################
+%# WeBWorK Online Homework Delivery System
+%# Copyright &copy; 2000-2023 The WeBWorK Project, https://github.com/openwebwork
+%#
+%# This program is free software; you can redistribute it and/or modify it under
+%# the terms of either: (a) the GNU General Public License as published by the
+%# Free Software Foundation; either version 2, or (at your option) any later
+%# version, or (b) the "Artistic License" which comes with this package.
+%#
+%# This program is distributed in the hope that it will be useful, but WITHOUT
+%# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+%# FOR A PARTICULAR PURPOSE.  See either the GNU General Public License or the
+%# Artistic License for more details.
+%################################################################################
+%
+% layout 'help_macro';
+% title maketext('Achievement Notification Editor Help');
+%
+<p>
+	<%= maketext('This page allows one to edit and set the achievement email notification template for an achievement. '
+		. ' In addition to setting an email notification template for an achievement here, you must also set the '
+		. '"email address to use when sending Achievement notifications" in the optional modules of the course '
+		. 'configuration in order for email notifications to be sent.') =%>
+</p>
+<h2><%= maketext('Actions:') %></h2>
+<p class="mb-2"><i><%= maketext('(If an action cannot be executed it will not appear.)') %></i></p>
+<dl>
+	<dt><%= maketext('Save') %></dt>
+	<dd><%= maketext('Save the contents of the editor window to the file on disk.') %></dd>
+
+	<dt><%= maketext('Save As') %></dt>
+	<dd>
+		<%= maketext(q{Makes a new copy of the file you are editing at the location relative to the course's }
+			. 'achievement notifications (~[ACHEVNOTIFYDIR~]) directory, and sets the new file to be the email '
+			. 'notification template for this achievement.') =%>
+	</dd>
+
+	<dt><%= maketext('Use Existing Template') %></dt>
+	<dd><%= maketext('Set an existing template file as the email notification template for this achievement') %></dd>
+
+	<dt><%= maketext('Disable Notifications') %></dt>
+	<dd><%= maketext('Disable email notifications for this achievement.') %></dd>
+</dl>
+<h2><%= maketext('Template Substitutions') %></h2>
+<p>
+	<%== maketext('The following variables are available for use in the template.  These variables can be used inside '
+		. '[_1] tags.  For example, [_2] will insert the description of the achievement into the email body.',
+	   	'<code>&lt;%= ... %&gt;</code>', '<code>&lt;%= $achievement->description %&gt;</code>') =%>
+</p>
+<ul class="mb-0">
+	<li><code>$ce</code>: This gives access to the entire course environment.</li>
+	<li><code>$achievement</code>: The database record for the achievement.</li>
+	<li><code>$setID</code>: The name of the set the student was working when the achievement was earned.</li>
+	<li><code>$nextLevelPoints</code>: The number of points that the student must attain to reach the next level.</li>
+	<li><code>$pointsEarned</code>: The number of achievement points earned for this achievement.</li>
+	<li><code>$user</code>: The database record for the student user.</li>
+	<li><code>$user_status</code>: The enrollment status of the user.</li>
+</ul>


### PR DESCRIPTION
The `$mail{achievementEmailFrom}` setting was not working because in the task it tried to use a non-existent `$mail{achievementEmailSender}` variable.

Make it so that achievement notifications are only sent if `$mail{achievementEmailFrom}` is set, and do NOT fall back to using `$mail{smtpSender}` or `$$mail{set_return_path}`.  Those are not valid for this in any way.

Make the default template only remark on the number of points remaining until the next level-up if `$nextLevelPoints` is set.  It is likely that a non-level achievement will occur before the first level achievement (for example if both of the one_click and level_one achievements are enabled, and the student gets the first question correct in one attempt) in which case the next level points has not been set yet. If that happens then the email says there are a negative number of points remaining until the next level-up.

Add a help file for the achievement notification editor page.

On the achievement list page, make the "Notifications" column say "Edit Email Template $templateName" if an email notification template is enabled for the achievement as requested by @somiaj.  I would be happy with reverting this though as it can make this column rather wide.

Remove all of the radio options in the "Save As" form, and just assume it is being saved for the current achievement.  I don't really see the need for any of those options.

Add the `[ACHEVDIR]` prefix to the "Save As" form, and add `dir => 'ltr'` to file names since those don't work right in right to left languages otherwise.

In the site navigation when editing an achievement evaluator, an achievement notification, or the achievement users, show sub links for all of those editors.

Change the `text_field` in the `existing_form.html.ep` to a `select_field` that shows all of the existing template files.

Don't use the WeBWorK::Utils::processEmailMessage method.  I see no reason for that.  There is not actually any merge data, so in reality this is only used to get the user's first name and potentially other information from the user record.  That can be passed directly to the template and used there, so that is done instead.  The default template is modified accordingly.

Lots of clean up of the AchievementNotificationEditor.pm file and the AchivievementNotification.pm file.

Instead of storing achievement email notification templates in the course templates/achievements directory directly, store them in templates/achievements/notifications subdirectory.  This directory is added to the list of directories in the `updateCourseDirectories` method of `WeBWorK::Utils::CourseIntegrityCheck` that can be copied from the modelCourse.  This has a couple of advantages.  First, most courses will not have this directory so if the modelCourse is updated, then this directory will be copied and get the default template when the course is upgraded from the admin course.  Second, it separates the achievement evaluator files from the achievement notification templates.